### PR TITLE
remove --remote=origin flag to avoid pulling commits that are not part of the default branch

### DIFF
--- a/cmd/git/git.go
+++ b/cmd/git/git.go
@@ -1626,8 +1626,8 @@ func (j *DSGit) ParseGitLog(ctx *shared.Ctx) (cmd *exec.Cmd, err error) {
 		j.log.WithFields(logrus.Fields{"operation": "ParseGitLog"}).Debugf("parsing logs from %s", j.GitPath)
 	}
 	// Example full command line:
-	// LANG=C PAGER='' git log --reverse --topo-order --branches --tags --remotes=origin --no-color --decorate --raw --numstat --pretty=fuller --decorate=full --parents -M -C -c
-	cmdLine := []string{"git", "log", "--reverse", "--topo-order", "--branches", "--tags", "--remotes=origin"}
+	// LANG=C PAGER='' git log --reverse --topo-order --branches --tags --no-color --decorate --raw --numstat --pretty=fuller --decorate=full --parents -M -C -c
+	cmdLine := []string{"git", "log", "--reverse", "--topo-order", "--branches", "--tags"}
 	cmdLine = append(cmdLine, GitLogOptions...)
 	if ctx.DateFrom != nil {
 		cmdLine = append(cmdLine, "--since="+shared.ToYMDHMSDate(*ctx.DateFrom))


### PR DESCRIPTION
Signed-off-by: Ibrahim Mbaziira <dev.code.ibra@gmail.com>

closes #60 